### PR TITLE
Action LOG. new FlagState. Placeholder for Flag_Set

### DIFF
--- a/core/src/main/java/me/fromgate/reactions/actions/ActionLog.java
+++ b/core/src/main/java/me/fromgate/reactions/actions/ActionLog.java
@@ -1,0 +1,71 @@
+/*  
+ *  ReActions, Minecraft bukkit plugin
+ *  (c)2012-2014, fromgate, fromgate@gmail.com
+ *  http://dev.bukkit.org/server-mods/reactions/
+ *    
+ *  This file is part of ReActions.
+ *  
+ *  ReActions is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  ReActions is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with ReActions.  If not, see <http://www.gnorg/licenses/>.
+ * 
+ */
+
+package me.fromgate.reactions.actions;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+
+import me.fromgate.reactions.ReActions;
+import me.fromgate.reactions.RAUtil;
+import com.google.common.base.Joiner;
+import me.fromgate.reactions.util.Param;
+import me.fromgate.reactions.util.playerselector.PlayerSelectors;
+import org.bukkit.entity.Player;
+import java.util.logging.Logger;
+
+public class ActionLog extends Action {
+    
+    private Logger log = Logger.getLogger("Minecraft");
+
+    @Override
+    public boolean execute(Player p, Param params) {
+        RAUtil u = ReActions.getUtil();
+        if (params.hasAnyParam("prefix", "color")) {
+          String plg_name = ReActions.getPlugin().getDescription().getName();
+          Boolean prefix = params.getParam("prefix", true);
+          Boolean color = params.getParam("color", false);
+          String message = params.getParam("text", removeParams(params.getParam("param-line")));
+          if (message.isEmpty()) return false;
+          if (prefix) {
+             this.log(message, plg_name, color);
+          } else this.log(message, "", color);
+        } else u.log(params.getParam("param-line"));
+        
+        return true;
+    }
+
+    private String removeParams(String message) {
+        StringBuilder sb = new StringBuilder("(?i)(");
+        sb.append(Joiner.on("|").join(PlayerSelectors.getAllKeys()));
+        sb.append("|hide|prefix|color):(\\{.*\\}|\\S+)\\s{0,1}");
+        return message.replaceAll(sb.toString(), "");
+
+    }
+
+    public void log(String msg, String prefix, Boolean color) {
+        String px = "";
+        if (prefix != "") px = "[" + prefix + "] ";
+        if (color) log.info(ChatColor.translateAlternateColorCodes('&', px + msg));
+        else log.info(ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', px + msg)));
+    }
+}

--- a/core/src/main/java/me/fromgate/reactions/actions/ActionMessage.java
+++ b/core/src/main/java/me/fromgate/reactions/actions/ActionMessage.java
@@ -69,7 +69,7 @@ public class ActionMessage extends Action {
         if (annoymentTime.isEmpty()) return true;
         long time = u().parseTime(annoymentTime);
         if (time == 0) return false;
-        String key = new StringBuilder("reactions-msg-").append(this.getActivatorName()).append(message.hashCode()).append((this.isAction() ? "act" : "react")).toString();
+        String key = new StringBuilder("reactions-msg-")/*.append(this.getActivatorName())*/.append(message.hashCode()).append((this.isAction() ? "act" : "react")).toString();
         if (player.hasMetadata(key)) {
             Long until = player.getMetadata(key).get(0).asLong();
             Long now = System.currentTimeMillis();

--- a/core/src/main/java/me/fromgate/reactions/actions/Actions.java
+++ b/core/src/main/java/me/fromgate/reactions/actions/Actions.java
@@ -102,7 +102,8 @@ public enum Actions {
     ACTION_DELAYED("actdelay", false, new ActionDelayed()),
     MENU_ITEM("itemmenu", true, new ActionMenuItem()),
     FCT_POWER_ADD("factaddpower", false, new ActionFactionsPowerAdd()),
-    WAIT("wait", false, new ActionWait());
+    WAIT("wait", false, new ActionWait()),
+    LOG("log", false, new ActionLog());
 
     private String alias;
     private boolean requireplayer;

--- a/core/src/main/java/me/fromgate/reactions/flags/FlagState.java
+++ b/core/src/main/java/me/fromgate/reactions/flags/FlagState.java
@@ -61,7 +61,8 @@ public class FlagState extends Flag {
             case VEHICLE_PIG:
                 if (!p.isInsideVehicle()) return false;
                 return p.getVehicle().getType() == EntityType.PIG;
-        }
+            case SPECTATOR_TARGET:
+                if (p.getSpectatorTarget() != null) return true;        }
         return false;
     }
 
@@ -75,7 +76,8 @@ public class FlagState extends Flag {
         VEHICLE_PIG,
         VEHICLE_HORSE,
         FLY,
-        OP;
+        OP,
+        SPECTATOR_TARGET;
 
         public static Posture getByName(String name) {
             for (Posture pt : Posture.values())

--- a/core/src/main/java/me/fromgate/reactions/flags/Flags.java
+++ b/core/src/main/java/me/fromgate/reactions/flags/Flags.java
@@ -134,6 +134,7 @@ public enum Flags {
     public static boolean checkFlag(Player p, String flag, String param, boolean not) {
         Flags ft = Flags.getByName(flag);
         if (ft == null) return false;
+        Variables.setTempVar(new StringBuilder(flag).append("_flag").toString().toUpperCase(), param);
         boolean check = ft.check(p, param);
         if (not) return !check;
         return check;


### PR DESCRIPTION
**English:**
1. Added a new action **LOG**.
**Using**:
This action is necessary to write to the server log the data you need. You can use it to debug activators.
**LOG <message> [prefix] [color]**
**<message>** - The message to be sent to the server log.
**prefix: <true | False>** - Non-mandatory parameter that shows or hides the plugin prefix ([ReActions]). Default **prefix: true**
**color: <true | False>** - A non-mandatory parameter that shows or hides text formatting. Default **prefix: false**

2. Added a new player state **SPECTATOR_TARGET** for the **STATE** flag.
This allows you to determine the state of the player who is in the player or entity.

3. Added a placeholder for FLAG_SET. It allows you to find out which flag is triggered from a group of flags. It is useful when you need to determine, for example, in which world the player is located or to which group the player belongs.
```
EXEC:
  test_flags:
    flags:
    - FLAG_SET=GROUP:default GROUP:fly GROUP:vip GROUP:vipp GROUP:god GROUP:mvp GROUP:mvpp GROUP:creative
    - FLAG_SET=WORLD:world WORLD:world_nether WORLD:world_the_end
    actions:
    - CMD_CONSOLE=say &ePlayer &a%player% &ebelongs to the group of &6&l%GROUP_FLAG%
    - CMD_CONSOLE=say &ePlayer &a%player% &eis located &6&l%WORLD_FLAG%
```
4. Fixed a bug in the MESSAGE action when the ** hide ** option is applied

/-------------------------/

**Russian:**
1. Добавлено новое действие **LOG**. 
**Применение**:
Это действие необходимо для записи в лог сервера нужных вам данных. Можно использовать для отладки активаторов.
**LOG <message> [prefix] [color]**
**<message>** - Сообщение, которое будет отправлено в лог сервера.
**prefix:<true | false>** - Не обязтельный параметр, который показывает или скрывает префикс плагина ([ReActions]). По умолчанию **prefix:true**
**color:<true | false>** - Не обязтельный параметр, который показывает или скрывает форматирование текста. По умолчанию **prefix:false**

2. Добавлено новое состояние игрока **SPECTATOR_TARGET** для флага **STATE**.
Это позволяет определять состояние вселившегося игрока в вдругом игроке или сущности.

3. Добавлен плейсхолдер для FLAG_SET. Позволяет узнать, какой флаг сработал из группы флагов. Полезно, когда нужно определить, например, в каком мире находится игрок или к какой группе принадлежит игрок.
```
EXEC:
  test_flags:
    flags:
    - FLAG_SET=GROUP:default GROUP:fly GROUP:vip GROUP:vipp GROUP:god GROUP:mvp GROUP:mvpp GROUP:creative
    - FLAG_SET=WORLD:world WORLD:world_nether WORLD:world_the_end
    actions:
    - CMD_CONSOLE=say &eИгрок &a%player% &eпринадлежит группе &6&l%GROUP_FLAG%
    - CMD_CONSOLE=say &eИгрок &a%player% &eв мире &6&l%WORLD_FLAG%
```

4. Пофиксен баг  в действии MESSAGE, когда применяется параметр **hide**