### PR TITLE
Add a BlockClick Activator

### DIFF
--- a/core/src/main/java/me/fromgate/reactions/RAListener.java
+++ b/core/src/main/java/me/fromgate/reactions/RAListener.java
@@ -39,6 +39,7 @@ import me.fromgate.reactions.event.FactionDisbandEvent;
 import me.fromgate.reactions.event.FactionEvent;
 import me.fromgate.reactions.event.FactionRelationEvent;
 import me.fromgate.reactions.event.ItemClickEvent;
+import me.fromgate.reactions.event.BlockClickEvent;
 import me.fromgate.reactions.event.ItemConsumeEvent;
 import me.fromgate.reactions.event.ItemHoldEvent;
 import me.fromgate.reactions.event.ItemWearEvent;
@@ -345,6 +346,7 @@ public class RAListener implements Listener {
     public void onPlayerInteract(PlayerInteractEvent event) {
         EventManager.raiseItemClickEvent(event);
         EventManager.raiseItemWearEvent(event.getPlayer());
+        if (EventManager.raiseBlockClickEvent(event)) event.setCancelled(true);
         if (EventManager.raiseButtonEvent(event)) event.setCancelled(true);
         EventManager.raisePlateEvent(event);
         if (EventManager.raiseLeverEvent(event)) event.setCancelled(true);
@@ -519,6 +521,11 @@ public class RAListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onMessageEvent(MessageEvent event) {
+        event.setCancelled(Activators.activate(event));
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onBlockClickActivator(BlockClickEvent event) {
         event.setCancelled(Activators.activate(event));
     }
 

--- a/core/src/main/java/me/fromgate/reactions/activators/ActivatorType.java
+++ b/core/src/main/java/me/fromgate/reactions/activators/ActivatorType.java
@@ -37,6 +37,7 @@ import me.fromgate.reactions.event.RegionEvent;
 import me.fromgate.reactions.event.RegionLeaveEvent;
 import me.fromgate.reactions.event.SignEvent;
 import me.fromgate.reactions.event.VariableEvent;
+import me.fromgate.reactions.event.BlockClickEvent;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -73,6 +74,7 @@ public enum ActivatorType {
     FCT_CREATE("fctcreate", FactionCreateActivator.class, FactionCreateEvent.class),
     FCT_DISBAND("fctdisband", FactionDisbandActivator.class, FactionDisbandEvent.class),
     SIGN("sign", SignActivator.class, SignEvent.class),
+    BLOCK_CLICK("blockclick", BlockClickActivator.class, BlockClickEvent.class),
     VARIABLE("var", VariableActivator.class, VariableEvent.class);
 
     private String alias;

--- a/core/src/main/java/me/fromgate/reactions/activators/BlockClickActivator.java
+++ b/core/src/main/java/me/fromgate/reactions/activators/BlockClickActivator.java
@@ -1,0 +1,130 @@
+package me.fromgate.reactions.activators;
+
+import me.fromgate.reactions.actions.Actions;
+import me.fromgate.reactions.event.BlockClickEvent;
+import me.fromgate.reactions.util.Locator;
+import me.fromgate.reactions.util.Param;
+import me.fromgate.reactions.util.Variables;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.Event;
+import org.bukkit.block.Block;
+
+public class BlockClickActivator extends Activator {
+    private String blockType;
+    private String blockLocation;
+    private ClickType click;
+
+    public BlockClickActivator(String name, String group, YamlConfiguration cfg) {
+        super(name, group, cfg);
+    }
+
+    public BlockClickActivator(String name, String param) {
+        super(name, "activators");
+        this.blockType = param;
+        this.blockLocation = "";
+        Param params = new Param(param);
+        if (params.isParamsExists("type")) {
+            this.blockType = params.getParam("type");
+            this.blockLocation = params.getParam("loc");
+        }
+        this.click = ClickType.getByName(params.getParam("click", "ANY"));
+    }
+
+
+    @Override
+    public boolean activate(Event event) {
+        if (!(event instanceof BlockClickEvent )) return false;
+        BlockClickEvent  bce = (BlockClickEvent ) event;
+        if (bce.getBlockClick() == null) return false;
+        if (!isActivatorBlock(bce.getBlockClick())) return false;
+        if (!clickCheck(bce.isLeftClicked())) return false;
+        Variables.setTempVar("blocklocation", Locator.locationToString(bce.getBlockClick().getLocation()));
+        Variables.setTempVar("blocktype", bce.getBlockClick().getType().name());
+        Variables.setTempVar("click", bce.isLeftClicked() ? "left" : "right");
+        return Actions.executeActivator(bce.getPlayer(), this);
+    }
+
+    private boolean checkLocations(Block block) {
+        if (this.blockLocation.isEmpty()) return true;
+        return this.isLocatedAt(block.getLocation());
+    }
+
+    private boolean isActivatorBlock(Block block) {
+        if (!(this.blockType).isEmpty() && !(block.getType()).toString().equalsIgnoreCase(this.blockType)) return false;
+        if (!checkLocations(block)) return false;
+        return true;
+    }
+
+
+    @Override
+    public boolean isLocatedAt(Location l) {
+        if (this.blockLocation.isEmpty()) return false;
+        Location loc = Locator.parseCoordinates(this.blockLocation);
+        if (loc == null) return false;
+        return l.getWorld().equals(loc.getWorld()) &&
+                l.getBlockX() == loc.getBlockX() &&
+                l.getBlockY() == loc.getBlockY() &&
+                l.getBlockZ() == loc.getBlockZ();
+    }
+
+
+    @Override
+    public void save(String root, YamlConfiguration cfg) {
+        cfg.set(root + ".block-type", this.blockType);
+        cfg.set(root + ".click-type", click.name());
+        cfg.set(root + ".location", this.blockLocation.isEmpty() ? null : this.blockLocation);
+    }
+
+    @Override
+    public void load(String root, YamlConfiguration cfg) {
+        this.blockType = cfg.getString(root + ".block-type", "");
+        click = ClickType.getByName(cfg.getString(root + ".click-type", "ANY"));
+        this.blockLocation = cfg.getString(root + ".location", "");
+    }
+
+    @Override
+    public ActivatorType getType() {
+        return ActivatorType.BLOCK_CLICK;
+    }
+
+    enum ClickType {
+        RIGHT,
+        LEFT,
+        ANY;
+
+        public static ClickType getByName(String clickStr) {
+            if (clickStr.equalsIgnoreCase("left")) return ClickType.LEFT;
+            if (clickStr.equalsIgnoreCase("any")) return ClickType.ANY;
+            return ClickType.RIGHT;
+        }
+    }
+
+    private boolean clickCheck(boolean leftClick) {
+        switch (click) {
+            case ANY:
+                return true;
+            case LEFT:
+                return leftClick;
+            case RIGHT:
+                return !leftClick;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(name).append(" [").append(getType()).append("]");
+        if (!getFlags().isEmpty()) sb.append(" F:").append(getFlags().size());
+        if (!getActions().isEmpty()) sb.append(" A:").append(getActions().size());
+        if (!getReactions().isEmpty()) sb.append(" R:").append(getReactions().size());
+        sb.append(" (");
+        sb.append("type:").append(blockType.isEmpty() ? "-" : blockType.toUpperCase());
+        sb.append(" click:").append(this.click.name());
+        sb.append(" loc:").append(blockLocation.isEmpty() ? "-" : blockLocation);
+        sb.append(")");
+        return sb.toString();
+    }
+
+}

--- a/core/src/main/java/me/fromgate/reactions/activators/BlockClickActivator.java
+++ b/core/src/main/java/me/fromgate/reactions/activators/BlockClickActivator.java
@@ -25,10 +25,8 @@ public class BlockClickActivator extends Activator {
         this.blockType = param;
         this.blockLocation = "";
         Param params = new Param(param);
-        if (params.isParamsExists("type")) {
-            this.blockType = params.getParam("type");
-            this.blockLocation = params.getParam("loc");
-        }
+        this.blockType = params.getParam("type", "");
+        this.blockLocation = params.getParam("loc", "");
         this.click = ClickType.getByName(params.getParam("click", "ANY"));
     }
 

--- a/core/src/main/java/me/fromgate/reactions/commands/CmdAdd.java
+++ b/core/src/main/java/me/fromgate/reactions/commands/CmdAdd.java
@@ -31,6 +31,7 @@ import me.fromgate.reactions.activators.RegionActivator;
 import me.fromgate.reactions.activators.RgEnterActivator;
 import me.fromgate.reactions.activators.RgLeaveActivator;
 import me.fromgate.reactions.activators.SignActivator;
+import me.fromgate.reactions.activators.BlockClickActivator;
 import me.fromgate.reactions.activators.VariableActivator;
 import me.fromgate.reactions.externals.RAWorldGuard;
 import me.fromgate.reactions.flags.Flags;
@@ -246,6 +247,9 @@ public class CmdAdd extends Cmd {
                     sign = (Sign) b.getState();
                 if (sign != null) activator = new SignActivator(name, param, sign);
                 else activator = new SignActivator(name, param);
+                break;
+            case BLOCK_CLICK:
+                activator = new BlockClickActivator(name, param);
                 break;
             case VARIABLE:
                 activator = new VariableActivator(name, param);

--- a/core/src/main/java/me/fromgate/reactions/event/BlockClickEvent.java
+++ b/core/src/main/java/me/fromgate/reactions/event/BlockClickEvent.java
@@ -1,0 +1,53 @@
+/*  
+ *  ReActions, Minecraft bukkit plugin
+ *  (c)2012-2014, fromgate, fromgate@gmail.com
+ *  http://dev.bukkit.org/server-mods/reactions/
+ *    
+ *  This file is part of ReActions.
+ *  
+ *  ReActions is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  ReActions is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with ReActions.  If not, see <http://www.gnorg/licenses/>.
+ * 
+ */
+
+package me.fromgate.reactions.event;
+
+import org.bukkit.Location;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+
+public class BlockClickEvent extends RAEvent {
+    private Block block;
+    boolean leftClick;
+
+    public BlockClickEvent(Player p, Block block, boolean leftClick) {
+        super(p);
+        this.block = block;
+        this.leftClick = leftClick;
+    }
+
+    public Block getBlockClick() {
+        return this.block;
+    }
+
+    public Location getBlockClickLocation() {
+        return block.getLocation();
+    }
+    
+    public boolean isLeftClicked() {
+        return leftClick;
+    }
+
+}

--- a/core/src/main/java/me/fromgate/reactions/event/EventManager.java
+++ b/core/src/main/java/me/fromgate/reactions/event/EventManager.java
@@ -457,4 +457,14 @@ public class EventManager {
         event.setQuitMessage(qu.getQuitMessage() == null || qu.getQuitMessage().isEmpty() ? null : ChatColor.translateAlternateColorCodes('&', qu.getQuitMessage()));
     }
 
+    public static boolean raiseBlockClickEvent(PlayerInteractEvent event) {
+        Boolean leftClick;
+        if (event.getAction() == Action.RIGHT_CLICK_BLOCK) leftClick = false;
+        else if (event.getAction() == Action.LEFT_CLICK_BLOCK) leftClick = true;
+        else return false;
+        BlockClickEvent e = new BlockClickEvent(event.getPlayer(), event.getClickedBlock(), leftClick);
+        Bukkit.getServer().getPluginManager().callEvent(e);
+        return e.isCancelled();
+    }
+    
 }


### PR DESCRIPTION
**English**:

Adding a new **Block_Click** activator
**Using**:
This activator works when the player clicks on the block with the left or right mouse button. It allows you to control the actions on the blocks. You can prohibit both the destruction of the blocks and their installation. You can apply these rules to both a single block and a group of blocks. The activator can be configured to prohibit the opening of any inventory that opens when you click on the relevant blocks (CHEST, HOPPER, BEACON, ..., etc.).

**/react add BLOCK_CLICK <ActivatorName> [type: <TypeMaterial>] [click: left | Right | Any] [location: <loc>]**
**type** - material type of the block. Can take an empty value if it is necessary to track the effects on all types of blocks.
**click: <left | Right Any>** - what mouse click on the block should be tracked.
**location: <loc>** - coordinates of the block to be controlled.

Temporary placeholders operating in this activator:
**%blocktype%** - block type
**%blocklocation%** - coordinates of the block
**%click%** - "left" or "right", depending on which mouse button you clicked on the block.

**Examples**:
1. Prohibition to edit the world. You can not put blocks or break them:
/react add BLOCK_CLICK bc
/react add bc a CANCEL_EVENT true
or
```
BLOCK_CLICK:
  bc:
    block-type: ''
    click-type: ANY
    actions:
    - CANCEL_EVENT=true
```
2. The prohibition of the opening of all chests in the world:
/react add BLOCK_CLICK bc2 type:CHEST click:right
/react add bc2 a CANCEL_EVENT true
or
```
BLOCK_CLICK:
  bc2:
    block-type: CHEST
    click-type: RIGHT
    actions:
    - CANCEL_EVENT=true
```
In this example, if **click-type: LEFT**, it will be forbidden to break all the chests, but it is allowed to open. If **click-type: ANY**, then it will be forbidden to break and open the chests.

3. Control of only one chest:
/react add BLOCK_CLICK bc3 type:CHEST click:right loc:world,100,60,100
/react add bc3 a CANCEL_EVENT true
or
```
BLOCK_CLICK:
  bc3:
    block-type: CHEST
    click-type: RIGHT
    location: world,100,60,100
    actions:
    - CANCEL_EVENT=true
```
**location: world,100,60,100** - chest block coordinates 

4. To forbid to break certain blocks in the world:
/react add BLOCK_CLICK bc4 type:CHEST click:left 
/react add bc4 f COMPARE param:%blocktype% value1:DIRT value2:GRASS value3:STONE
/react add bc4 a CANCEL_EVENT true
or
```
BLOCK_CLICK:
  bc4:
    block-type: ''
    click-type: LEFT
    flags:
    - COMPARE=param:%blocktype% value1:DIRT value2:GRASS value3:STONE
    actions:
    - CANCEL_EVENT=true
```
You can come up with a lot of things with this activator.

/-------------------------/

**Russian**:

Добавление нового активатора **Block_Click**
**Применение**:
Этот активатор срабатывает, когда игрок кликает по блоку левой или правой кнопкой мыши. Он даёт возможность контролировать действия над блоками. Можно запретить как уничтожения блоков так и их установку. Можно применять эти правила, как для одного блока, так и группы блоков. Активатор можно настроить на запрет открытия любого инвентаря, который открывается при клике на соответствующие блоки (CHEST, HOPPER, BEACON, ... и т.п. ).

**/react add BLOCK_CLICK <ИмяАктиватора> [type:<ТипМатериала>] [click:left | right | any] [location:<loc>]**
**type** - тип материала блока. Может принимать пустое значение, если необходимо отслеживать воздействия на все типы блоков.
**click: <left | right | any>** - какой клик мыши по блоку необходимо отслеживать.
**location: <loc>** - координаты блока, который необходимо контролировать.

Временные плейсхолдеры, действующие в этом активаторе:
**%blocktype%** - тип блока
**%blocklocation%** - координаты блока
**%click%** - "left" или "right" в зависимости от того какой кнопкой мыши кликнули по блоку.

Примеры:
1. Запрет на редактирование мира. Нельзя ни поставить блоки, ни сломать их:
/react add BLOCK_CLICK bc
/react add bc a CANCEL_EVENT true
или
```
BLOCK_CLICK:
  bc:
    block-type: ''
    click-type: ANY
    actions:
    - CANCEL_EVENT=true
```
2. Запрет открытия всех сундуков в мире:
/react add BLOCK_CLICK bc2 type:CHEST click:right
/react add bc2 a CANCEL_EVENT true
или 
```
BLOCK_CLICK:
  bc2:
    block-type: CHEST
    click-type: RIGHT
    actions:
    - CANCEL_EVENT=true
```
В этом примере, если click-type: LEFT, то запрещено будет разбивать все сундуки, но разрешено открывать. Если click-type: ANY, то будет запрещено и разбивать и открывать сундуки.

3. Контроль только над одним сундуком (блоком):
/react add BLOCK_CLICK bc3 type:CHEST click:right loc:world,100,60,100
/react add bc3 a CANCEL_EVENT true
или 
```
BLOCK_CLICK:
  bc3:
    block-type: CHEST
    click-type: RIGHT
    location: world,100,60,100
    actions:
    - CANCEL_EVENT=true
```
где **location: world,100,60,100** - координаты сундука

4. Запретить ломать определённые блоки в мире:
/react add BLOCK_CLICK bc4 type:CHEST click:left 
/react add bc4 f COMPARE param:%blocktype% value1:DIRT value2:GRASS value3:STONE
/react add bc4 a CANCEL_EVENT true
или 
```
BLOCK_CLICK:
  bc4:
    block-type: ''
    click-type: LEFT
    flags:
    - COMPARE=param:%blocktype% value1:DIRT value2:GRASS value3:STONE
    actions:
    - CANCEL_EVENT=true
```

Можно ещё много вещей придумать с этим активатром.